### PR TITLE
TypeError: can't pickle instancemethod objects when including init/validate/setup methods

### DIFF
--- a/examples/hello_world/hello_world.py
+++ b/examples/hello_world/hello_world.py
@@ -55,3 +55,27 @@ class cls_hello_world_validate_py(object):
 
     def run(self):
         print "Hello World"
+
+@pytool()
+class cls_hello_world_othermethod_py(object):
+    def foo(self):
+        pass
+
+    def run(self):
+        print "Hello World"
+
+@pytool()
+class cls_hello_world_init_py(object):
+    def init(self):
+        pass
+
+    def run(self):
+        print "Hello World"
+
+@pytool()
+class cls_hello_world_setup_py(object):
+    def setup(self):
+        pass
+
+    def run(self):
+        print "Hello World"

--- a/examples/hello_world/hello_world.py
+++ b/examples/hello_world/hello_world.py
@@ -47,3 +47,11 @@ class cls_hello_world_perl(object):
 class cls_hello_world_py(object):
     def run(self):
         print "Hello World"
+
+@pytool()
+class cls_hello_world_validate_py(object):
+    def validate(self):
+        pass
+
+    def run(self):
+        print "Hello World"

--- a/test/test_pickler.py
+++ b/test/test_pickler.py
@@ -105,3 +105,21 @@ def test_storing_embdded_pipeline():
     assert len(emb) == 1
     data = pickle.dumps(emb)
     assert data is not None
+
+@jip.pytool()
+class mytool(object):
+    """
+    usage:
+        tool <name>
+    """
+    def validate(self):
+        pass
+
+    def run(self):
+        pass
+
+def test_pickels_job_with_instance_method():
+
+    p = jip.Pipeline()
+    p.run('mytool', name='foo')
+    jobs = jip.create_jobs(p)


### PR DESCRIPTION
When building python classes and wrapping them with `@pytool` it throws an exception if you have init, setup or validate methods

```
 for t in validate init setup; do JIP_MODULES=hello_world.py jip run cls_hello_world_${t}_py; done
```

```
Traceback (most recent call last):
  File "/media/VD_Research/People/tyghe.vallard/Projects/bioframework/myconda/bin/jip", line 9, in <module>
    load_entry_point('pyjip', 'console_scripts', 'jip')()
  File "/media/VD_Research/People/tyghe.vallard/Projects/bioframework/myconda/lib/python2.7/site-packages/jip/cli/jip_main.py", line 81, in main
    _main()
  File "/media/VD_Research/People/tyghe.vallard/Projects/bioframework/myconda/lib/python2.7/site-packages/jip/cli/jip_main.py", line 131, in _main
    runpy.run_module("jip.cli.jip_%s" % cmd, run_name="__main__")
  File "/media/VD_Research/People/tyghe.vallard/Projects/bioframework/myconda/lib/python2.7/runpy.py", line 180, in run_module
    fname, loader, pkg_name)
  File "/media/VD_Research/People/tyghe.vallard/Projects/bioframework/myconda/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/media/VD_Research/People/tyghe.vallard/Projects/bioframework/myconda/lib/python2.7/site-packages/jip/cli/jip_run.py", line 107, in <module>
    main()
  File "/media/VD_Research/People/tyghe.vallard/Projects/bioframework/myconda/lib/python2.7/site-packages/jip/cli/jip_run.py", line 67, in main
    profile=profile)
  File "/media/VD_Research/People/tyghe.vallard/Projects/bioframework/myconda/lib/python2.7/site-packages/jip/jobs.py", line 1096, in create_jobs
    job = from_node(node, keep=keep)
  File "/media/VD_Research/People/tyghe.vallard/Projects/bioframework/myconda/lib/python2.7/site-packages/jip/jobs.py", line 971, in from_node
    cmds = node._tool.get_command()
  File "/media/VD_Research/People/tyghe.vallard/Projects/bioframework/myconda/lib/python2.7/site-packages/jip/tools.py", line 1609, in get_command
    return self.decorator.get_command(self, self.instance)
  File "/media/VD_Research/People/tyghe.vallard/Projects/bioframework/myconda/lib/python2.7/site-packages/jip/tools.py", line 358, in get_command
    (cPickle.dumps(data).encode("base64")))
  File "/media/VD_Research/People/tyghe.vallard/Projects/bioframework/myconda/lib/python2.7/copy_reg.py", line 70, in _reduce_ex
    raise TypeError, "can't pickle %s objects" % base.__name__
TypeError: can't pickle instancemethod objects
```
